### PR TITLE
Should use LDLIBS for -lzzz parameters.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,12 +1,12 @@
 CFLAGS=-Wall -Wextra -O2 -std=c17 -g $(shell pkgconf --cflags glib-2.0) -D_POSIX_C_SOURCE=200809L -D_DEFAULT_SOURCE -D__USE_FILE_OFFSET64 -D_GNU_SOURCE
-LDFLAGS=$(shell pkgconf --libs glib-2.0)
+LDLIBS=$(shell pkgconf --libs glib-2.0)
 OBJS=lansrm.o srm.o rmp.o config.o debug.o epoll.o
 HDRS=Makefile lansrm.h srm.h rmp.h epoll.h config.h debug.h
 
 all: lansrm
 
 lansrm: $(OBJS)
-	$(CC) $(LDFLAGS) -o $@ $^
+	$(CC) $(LDFLAGS) -o $@ $^ $(LDLIBS)
 
 %.o:	%.c $(HDRS)
 	$(CC) $(CFLAGS) -c -o $@ $<


### PR DESCRIPTION
Per (a) make [manual](https://www.gnu.org/software/make/manual/html_node/Implicit-Variables.html), LDLIBS should be used for -lzzz parameters.